### PR TITLE
common.prf: removes linker and include dependency on install path

### DIFF
--- a/common.prf
+++ b/common.prf
@@ -17,6 +17,3 @@ coverage {
   QMAKE_LFLAGS   += $$COVERAGE_FLAGS
   CONFIG += debug
 }
-
-LIBS += -L$$LIBDIR
-INCLUDEPATH += $$INCDIR


### PR DESCRIPTION
The include path causes problems on archlinux build.

Anyway, I think we should not depend on PREFIX variable in these
cases, eg. build during a debianization will have these directories
point to somewhere under debian, being empty.
