### PR TITLE
testcommon.prf: find the libraries for tests on macos

### DIFF
--- a/testcommon.prf
+++ b/testcommon.prf
@@ -20,6 +20,9 @@ windows {
     check.commands = wine $$check.commands
   }
   check.commands = "cp $${build_path}/qlogsystem*.dll . &&" $$check.commands
+} macx {
+  # QMAKE_RPATHDIR is unfortunately not working on macos
+  check.commands = "env DYLD_LIBRARY_PATH='$${build_path}'" $$check.commands
 } else {
   QMAKE_RPATHDIR += $${OUT_PWD}/../../qlogsystem
 }


### PR DESCRIPTION
On macos build, QMAKE_RPATH_DIR seems not have any affect, and libqlogsystem.1.dylib gets linked without path in the tests.

An alternative is to run the tests like:
DYLD_LIBRARY_PATH="path to the dylib" make check

Unfortunetly, this variable gets lost (not inherited) if a subshell gets opened on macs where "system integrity protection" is turned on. (And tests get run with a wrapper.sh which Qt generates.) So I think it is better set this environment in the wrapper.sh