### PR TITLE
libinstall.prf: initialize the prefix of pkg-config on macOS

### DIFF
--- a/libinstall.prf
+++ b/libinstall.prf
@@ -7,6 +7,7 @@ INSTALL_PREFIX = $${INCDIR}/$$replace(_PRO_FILE_PWD_, $$re_escape($$PWD), "")
 INSTALL_HEADERS = $$HEADERS
 include(headerinstall.prf)
 
+macx: QMAKE_PKGCONFIG_PREFIX = $$PREFIX
 QMAKE_PKGCONFIG_NAME = $$TARGET
 QMAKE_PKGCONFIG_DESTDIR = pkgconfig
 QMAKE_PKGCONFIG_INCDIR = ${prefix}/include


### PR DESCRIPTION
Further details in commit message.