### PR TITLE
Check qt version for use QTextStream::setCodec

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qlogsystem (1.1.3) focal; urgency=low
+
+  * compatibility with qt6
+
+ -- Botond Petras  <botond.petras@quest.com>  Tue 05 Jul 2022 11:55:00 +0100
+
 qlogsystem (1.1.2) bionic; urgency=low
 
   * choose maxID for the given version

--- a/qlogsystem/iodeviceoutput.cc
+++ b/qlogsystem/iodeviceoutput.cc
@@ -38,7 +38,9 @@ namespace LOG
       : device(device),
         stream(device)
     {
-      stream.setCodec("utf-8");
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+      stream.setCodec("UTF-8");
+#endif
     }
 
     ~IODeviceOutputPrivate()

--- a/qlogsystem/loghelpers.hh
+++ b/qlogsystem/loghelpers.hh
@@ -105,7 +105,10 @@ namespace LOG
     QString message;
 
     QTextStream stream(&message);
-    stream.setCodec("utf-8");
+    
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    stream.setCodec("UTF-8");
+#endif
 
     param1.delimiter = QString(";");
 

--- a/qlogsystem/logspechandler.cc
+++ b/qlogsystem/logspechandler.cc
@@ -137,7 +137,9 @@ void
 LogSpecHandlerPrivate::createErrorString(const QString &log_spec, int pos)
 {
   QTextStream stream(&errorString);
-  stream.setCodec("utf-8");
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  stream.setCodec("UTF-8");
+#endif
 
   stream << "Invalid logspec syntax:" << Qt::endl << Qt::endl;
   stream << log_spec << Qt::endl;


### PR DESCRIPTION
For Qt6 compatibility.
In Qt6 the default codec is UTF-8
QTextStream::setCodec does not exist in Qt6